### PR TITLE
Inspect rebalancing

### DIFF
--- a/pyconnect/core.py
+++ b/pyconnect/core.py
@@ -1,7 +1,7 @@
 from confluent_kafka import KafkaException
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import List, Dict, Callable, Any
+from typing import Callable
 import logging
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,6 @@ class BaseConnector(metaclass=ABCMeta):
         self._before_run_loop()
         self._run_loop()
         self._after_run_loop()
-        self._status
 
     def _run_loop(self):
         while self.is_running:
@@ -64,9 +63,7 @@ class BaseConnector(metaclass=ABCMeta):
         self._status = Status.CRASHED
         self._status_info = e
 
-    def _safe_call_and_set_status(self, callback: Callable,
-                                  *args: List[Any],
-                                  **kwargs: Dict[Any, Any]) -> None:
+    def _safe_call_and_set_status(self, callback: Callable, *args, **kwargs) -> None:
         try:
             new_status = callback(*args, **kwargs)
         except Exception as e:

--- a/test/test_pyconnectsink.py
+++ b/test/test_pyconnectsink.py
@@ -5,7 +5,7 @@ from pyconnect.pyconnectsink import Status
 from pyconnect.config import SinkConfig
 
 
-from test.utils import PyConnectTestSink
+from test.utils import PyConnectTestSink, TestException
 
 # noinspection PyUnresolvedReferences
 from test.utils import failing_callback, message_factory, error_message_factory
@@ -65,7 +65,7 @@ def test_callbacks_are_called(sink_factory, message_factory, error_message_facto
             msg,
             None,
             error_msg,
-            Exception()]
+            TestException()]
 
     # perform
     connect_sink.run()
@@ -129,7 +129,7 @@ def test_last_message_is_unset(sink_factory, message_factory):
     # setup
     msg = message_factory()
     connect_sink = sink_factory()
-    connect_sink._consumer.poll.side_effect = [msg, Exception()]
+    connect_sink._consumer.poll.side_effect = [msg, TestException()]
 
     # perform
     connect_sink.run()
@@ -141,7 +141,7 @@ def test_last_message_is_unset(sink_factory, message_factory):
 def test_status_info_is_set(sink_factory, message_factory):
     # setup
     msg = message_factory()
-    exception = Exception()
+    exception = TestException()
     connect_sink = sink_factory()
     connect_sink._consumer.poll.side_effect = [msg, exception]
 
@@ -155,7 +155,7 @@ def test_status_info_is_set(sink_factory, message_factory):
 def test_status_info_is_unset(sink_factory):
     # setup
     connect_sink = sink_factory()
-    connect_sink._consumer.poll.side_effect = [Exception(), None]
+    connect_sink._consumer.poll.side_effect = [TestException(), None]
     connect_sink.on_crash = mock.Mock(return_value=Status.RUNNING)
     connect_sink.forced_status_after_run = [None, Status.STOPPED]
 


### PR DESCRIPTION
Rebalancing issues during e2e testing were resolved by introducing EOF tracking per topic and partition. This way we can decide whether a `None` returned by `consumer.poll()` is due to lack of new messages or due to internal events still going on.